### PR TITLE
added Maven compiler, source plugin and Junit dependencies for smoother integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,5 +50,37 @@
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+		</dependency>
+
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
I added a compile time Junit dependency, as well as `maven-source-plugin` and `maven-compiler-plugin` explicit dependencies so that one can use Maven to install a packaged jar into the local repository and directly import it as a Maven dependency in another project.

To compile and install, `$ mvn install` in root directory (copies JARs to `~/.m2/repository/<groupId>/<artifactId>`)

To use in another project, add the following into the `pom.xml` file:
```
<dependency>
    <groupId>woodser</groupId>
    <artifactId>monero-wallet-java</artifactId>
    <version>0.0.2-SNAPSHOT</version>
</dependency>
```